### PR TITLE
Add Brazilian Portuguese translation

### DIFF
--- a/src/main/resources/assets/extendedwrenches/lang/pt_br.json
+++ b/src/main/resources/assets/extendedwrenches/lang/pt_br.json
@@ -1,0 +1,9 @@
+{
+  "extendedwrenches.recipe.wrench_material_swap": "Forja de Chave-inglesa",
+  "item.extendedwrenches.incomplete_wrench_head_augment": "Melhoria incompleta de cabeça para chave-inglesa",
+  "item.extendedwrenches.nope_fake_wrench_name_i_hate_you_registrate": "Chave-inglesa",
+  "item.extendedwrenches.wrench_axis_augment": "Melhoria de eixo para chave-inglesa",
+  "item.extendedwrenches.wrench_cog_augment": "Melhoria de engrenagem para chave-inglesa",
+  "item.extendedwrenches.wrench_handle_augment": "Melhoria de cabo para chave-inglesa",
+  "item.extendedwrenches.wrench_head_augment": "Melhoria de cabeça para chave-inglesa"
+}


### PR DESCRIPTION
Had a couple of doubts on which names to use for which parts.

Create uses "Chave-inglesa" for wrench, but the name you'd usually see for this tool is "Grifo". I went with the Create translation for the sake of consistency.

Wrench Smithing also got me thinking for a bit, since there isn't a good substitute in portuguese for "smithing" in the general sense. I eventually landed on the portuguese equivalent of "forging", "Forja de Chave-inglesa", because it best reflects the tool station you use, a "forging" station.